### PR TITLE
chore: remove pywin32 from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -121,7 +121,6 @@ pyreadline3==3.5.4
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
 pytz==2025.2
-pywin32==310
 PyYAML==6.0.2
 pyzmq==26.4.0
 referencing==0.36.2


### PR DESCRIPTION
Remove pywin32==310 from requirements.txt to avoid unnecessary
dependency and potential compatibility issues on non-Windows
platforms. This change streamlines the dependency list and reduces
installation overhead.