### PR TITLE
chore: add pysqlite-binary and pysqlite3 to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -162,3 +162,5 @@ wrapt==1.17.2
 yarl==1.20.0
 zipp==3.21.0
 zstandard==0.23.0
+pysqlite-binary==0.5.1.3380300
+pysqlite3==0.5.2


### PR DESCRIPTION
Include pysqlite-binary and pysqlite3 packages in requirements.txt
to ensure SQLite support and compatibility with database operations.