### PR TITLE
chore: update pysqlite dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -162,5 +162,5 @@ wrapt==1.17.2
 yarl==1.20.0
 zipp==3.21.0
 zstandard==0.23.0
-pysqlite-binary==0.5.1.3380300
-pysqlite3==0.5.2
+pysqlite3-binary
+pysqlite3


### PR DESCRIPTION
Replace fixed version pysqlite-binary and pysqlite3 with more
flexible pysqlite3-binary and pysqlite3 entries to improve package
compatibility and allow for easier updates. This change helps avoid
version conflicts and